### PR TITLE
Fix: go:embed path( etc -> Etc)

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nyaosorg/nyagos/mains"
 )
 
-//go:embed etc/version.txt
+//go:embed Etc/version.txt
 var version string
 
 func main() {


### PR DESCRIPTION
**概要**

main.go の go:embed の パス文字列が `etc/version.txt` だとエラーになってしまうので `Etc/version.txt` に修正しました

発生したエラー

```
main.go:15:12: pattern etc/version.txt: no matching files found
```