### PR TITLE
feat: fuzzy finder extension integration(catalog)

### DIFF
--- a/nyagos.d/catalog/fuzzyfinder.lua
+++ b/nyagos.d/catalog/fuzzyfinder.lua
@@ -3,22 +3,19 @@ if not nyagos then
     os.exit()
 end
 
-local fzf = {}
-fzf.cmd          =  "fzf.exe"
-fzf.args         =  {}
-fzf.args.dir     =  ""
-fzf.args.cmdhist =  ""
-fzf.args.cdhist  =  ""
-fzf.args.gitlog  =  "--preview='git show {1}'"
+-- default/non-configured setting: Use fzf
+local ff = {}
+ff.cmd          =  "fzf.exe"
+ff.args         =  {}
+ff.args.dir     =  ""
+ff.args.cmdhist =  ""
+ff.args.cdhist  =  ""
+ff.args.gitlog  =  "--preview='git show {1}'"
 
-share.fuzzyfinder = share.fuzzyfinder or fzf
+share.fuzzyfinder = share.fuzzyfinder or ff
 
-share.fuzzyfinder.cmd          = share.fuzzyfinder.cmd          or "fzf.exe"
-share.fuzzyfinder.args         = share.fuzzyfinder.args         or {}
-share.fuzzyfinder.args.dir     = share.fuzzyfinder.args.dir     or ""
-share.fuzzyfinder.args.cmdhist = share.fuzzyfinder.args.cmdhist or ""
-share.fuzzyfinder.args.cdhist  = share.fuzzyfinder.args.cdhist  or ""
-share.fuzzyfinder.args.gitlog  = share.fuzzyfinder.args.gitlog  or ""
+-- Compatibility settings with old settings
+share.selector = share.fuzzyfinder.cmd
 
 nyagos.alias.dump_temp_out = function()
     for _,val in ipairs(share.dump_temp_out) do

--- a/nyagos.d/catalog/fuzzyfinder.lua
+++ b/nyagos.d/catalog/fuzzyfinder.lua
@@ -3,14 +3,22 @@ if not nyagos then
     os.exit()
 end
 
--- default/non-configured setting: Use fzf
+-- default/non-configured setting: Use fzf(exists)/peco
 local ff = {}
-ff.cmd          =  "fzf.exe"
+if nyagos.which("fzf.exe") then
+  ff.cmd        =  "fzf.exe"
+else
+  ff.cmd        =  "peco.exe"
+end
 ff.args         =  {}
 ff.args.dir     =  ""
 ff.args.cmdhist =  ""
 ff.args.cdhist  =  ""
-ff.args.gitlog  =  "--preview='git show {1}'"
+if nyagos.which("fzf.exe") then
+  ff.args.gitlog  =  "--preview='git show {1}'"
+else
+  ff.args.gitlog  =  ""
+end
 
 share.fuzzyfinder = share.fuzzyfinder or ff
 

--- a/nyagos.d/catalog/fzf.lua
+++ b/nyagos.d/catalog/fzf.lua
@@ -1,0 +1,16 @@
+if not nyagos then
+    print("This is a script for nyagos not lua.exe")
+    os.exit()
+end
+
+local fzf = {}
+fzf.cmd          =  "fzf.exe"
+fzf.args         =  {}
+fzf.args.dir     =  ""
+fzf.args.cmdhist =  ""
+fzf.args.cdhist  =  ""
+fzf.args.gitlog  =  "--preview='git show {1}'"
+
+share.fuzzyfinder = fzf
+
+use "fuzzyfinder"

--- a/nyagos.d/catalog/peco.lua
+++ b/nyagos.d/catalog/peco.lua
@@ -3,54 +3,14 @@ if not nyagos then
     os.exit()
 end
 
-share.selecter = share.selecter or "peco"
+local peco = {}
+peco.cmd          =  "peco.exe"
+peco.args         =  {}
+peco.args.dir     =  ""
+peco.args.cmdhist =  ""
+peco.args.cdhist  =  ""
+peco.args.gitlog  =  ""
 
-nyagos.alias.dump_temp_out = function()
-    for _,val in ipairs(share.dump_temp_out) do
-        nyagos.write(val,"\n")
-    end
-end
+share.fuzzyfinder = peco
 
-nyagos.bindkey("C-o",function(this)
-    local word,pos = this:lastword()
-    word = string.gsub(word,'"','')
-    share.dump_temp_out = nyagos.glob(word.."*")
-    local result=nyagos.eval('dump_temp_out | ' .. share.selecter)
-    this:call("CLEAR_SCREEN")
-    if string.find(result," ",1,true) then
-        result = '"'..result..'"'
-    end
-    assert( this:replacefrom(pos,result) )
-end)
-
-nyagos.alias.__dump_history = function()
-    local uniq={}
-    for i=nyagos.gethistory()-1,1,-1 do
-        local line = nyagos.gethistory(i)
-        if line ~= "" and not uniq[line] then
-            nyagos.write(line,"\n")
-            uniq[line] = true
-        end
-    end
-end
-
-nyagos.bindkey("C_R", function(this)
-    local result = nyagos.eval('__dump_history | ' .. share.selecter)
-    this:call("CLEAR_SCREEN")
-    return result
-end)
-
-nyagos.bindkey("M_H" , function(this)
-    local result = nyagos.eval('cd --history | ' .. share.selecter)
-    this:call("CLEAR_SCREEN")
-    if string.find(result,' ') then
-        result = '"'..result..'"'
-    end
-    return result
-end)
-
-nyagos.bindkey("M_G" , function(this)
-    local result = nyagos.eval('git log --pretty="format:%h %s" | ' .. share.selecter)
-    this:call("CLEAR_SCREEN")
-    return string.match(result,"^%S+") or ""
-end)
+use "fuzzyfinder"


### PR DESCRIPTION
このPRでは以下のような統合を行います。

* peco.lua の peco 利用について fuzzyfinder.lua を利用するように変更し、統合
* fuzzyfinder.lua の初期設定を整理(最初にいろいろやっているが、後から壊れた値を share.fuzzyfinder にセットしたときどうしようもないので、その部分を削除)
* fzf 利用を明確に行う fzf.lua を新設

これにより

* fuzzy finder 全般は fuzzyfinder.lua が担う
* peco.lua 利用者は変更なしで挙動変化なし
* fzf を明示的に利用したい人の簡便な方法を提供
* 設定無しで fuzzyfinder.lua を利用していた人も最低限挙動を保証

利用例

example 1. peco を簡単につかう

```lua
use "peco"
```
example 2. fzf を簡単につかう

```lua
use "fzf"
```

example 3.任意のfuzzyfinderを使う(カスタム設定)
ここでは https://github.com/rschmitt/heatseeker を利用する例
peco/fzfでもより詳しく設定したいなら同様に行う

```lua
use "fuzzyfinder"

local hs = {}
hs.cmd          = 'hs.exe'
hs.args         = {}
hs.args.dir     = ''
hs.args.cmdhist = '-F'
hs.args.cdhist  = ''
hs.args.gitlog  = '--filter-only'

share.fuzzyfinder = hs
```

example 4.設定なしの場合
最低限 fzf(あれば)/peco が設定される
```lua
use "fuzzyfinder"
```