### PR TITLE
linux で which したときに常に見つからない問題を修正しました

### DIFF
--- a/internal/nodos/lookpath.go
+++ b/internal/nodos/lookpath.go
@@ -18,7 +18,7 @@ func lookPath(dir1, targetPath string) (foundpath string) {
 	}
 	foundIndex := 999
 	findfile.Walk(targetPath+"*", func(f *findfile.FileInfo) bool {
-		if f.IsDir() || filepath.Ext(f.Name()) == "" {
+		if lookPathSkip(f) {
 			return true
 		}
 		if i, ok := names[strings.ToUpper(f.Name())]; ok && i < foundIndex {

--- a/internal/nodos/lookpath_unix.go
+++ b/internal/nodos/lookpath_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+// +build !windows
+
+package nodos
+
+import (
+	"github.com/nyaosorg/go-windows-findfile"
+)
+
+func lookPathSkip(f *findfile.FileInfo) bool {
+	return f.IsDir()
+}

--- a/internal/nodos/lookpath_windows.go
+++ b/internal/nodos/lookpath_windows.go
@@ -1,9 +1,7 @@
 package nodos
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/nyaosorg/go-windows-findfile"
 )

--- a/internal/nodos/lookpath_windows.go
+++ b/internal/nodos/lookpath_windows.go
@@ -1,0 +1,13 @@
+package nodos
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nyaosorg/go-windows-findfile"
+)
+
+func lookPathSkip(f *findfile.FileInfo) bool {
+	return f.IsDir() || filepath.Ext(f.Name()) == ""
+}


### PR DESCRIPTION
最近、 `wezterm + nyagos` を Windows と Linux 共用で使ってます。

ubuntu で lua の `nyagos.which('cp')` がうまくいかないので発見しました。
