### PR TITLE
Correct link path to README in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The Nihongo Yet Another GOing Shell
 ===================================
 
-**&lt;English&gt;** / [&lt;Japanese&gt;](./readme_ja.md)
+**&lt;English&gt;** / [&lt;Japanese&gt;](./README_ja.md)
 
 NYAGOS is the commandline-shell written with the Programming Language GO and Lua.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,7 +6,7 @@
 The Nihongo Yet Another GOing Shell
 ===================================
 
-[&lt;English&gt;](./readme.md) / **&lt;Japanese&gt;**
+[&lt;English&gt;](./README.md) / **&lt;Japanese&gt;**
 
 NYAGOS は Go と Lua で記述されたコマンドラインシェルです。
 

--- a/docs/01-Install_en.md
+++ b/docs/01-Install_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./01-Install_ja.md)
+[top](../README.md) &gt; English / [Japanese](./01-Install_ja.md)
 
 ## Install
 

--- a/docs/01-Install_ja.md
+++ b/docs/01-Install_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](01-Install_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](01-Install_en.md) / Japanese
 
 インストール
 ------------

--- a/docs/02-Options_en.md
+++ b/docs/02-Options_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./02-Options_ja.md)
+[top](../README.md) &gt; English / [Japanese](./02-Options_ja.md)
 
 
 ## Option for NYAGOS.EXE

--- a/docs/02-Options_ja.md
+++ b/docs/02-Options_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./02-Options_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./02-Options_en.md) / Japanese
 
 ## 起動オプション
 

--- a/docs/03-Readline_en.md
+++ b/docs/03-Readline_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./03-Readline_ja.md)
+[top](../README.md) &gt; English / [Japanese](./03-Readline_ja.md)
 
 ## Editor
 

--- a/docs/03-Readline_ja.md
+++ b/docs/03-Readline_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./03-Readline_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./03-Readline_en.md) / Japanese
 
 ## 編集機能
 

--- a/docs/04-Commands_en.md
+++ b/docs/04-Commands_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./04-Commands_ja.md)
+[top](../README.md) &gt; English / [Japanese](./04-Commands_ja.md)
 
 ## Built-in commands
 

--- a/docs/04-Commands_ja.md
+++ b/docs/04-Commands_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./04-Commands_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./04-Commands_en.md) / Japanese
 
 ## 内蔵コマンド
 

--- a/docs/05-Startup_en.md
+++ b/docs/05-Startup_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./05-Startup_ja.md)
+[top](../README.md) &gt; English / [Japanese](./05-Startup_ja.md)
 
 ## What is done on the Startup
 

--- a/docs/05-Startup_ja.md
+++ b/docs/05-Startup_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./05-Startup_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./05-Startup_en.md) / Japanese
 
 ## 起動処理
 

--- a/docs/06-Substitution_en.md
+++ b/docs/06-Substitution_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./06-Substitution_ja.md)
+[top](../README.md) &gt; English / [Japanese](./06-Substitution_ja.md)
 
 ## Substitution
 

--- a/docs/06-Substitution_ja.md
+++ b/docs/06-Substitution_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./06-Substitution_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./06-Substitution_en.md) / Japanese
 
 ## コマンドライン置換
 

--- a/docs/07-LuaFunctions_en.md
+++ b/docs/07-LuaFunctions_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./07-LuaFunctions_ja.md)
+[top](../README.md) &gt; English / [Japanese](./07-LuaFunctions_ja.md)
 
 ## Lua functions extenteded by NYAGOS
 

--- a/docs/07-LuaFunctions_ja.md
+++ b/docs/07-LuaFunctions_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./07-LuaFunctions_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./07-LuaFunctions_en.md) / Japanese
 
 ## Lua拡張
 

--- a/docs/08-Uninstall_en.md
+++ b/docs/08-Uninstall_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./08-Uninstall_ja.md)
+[top](../README.md) &gt; English / [Japanese](./08-Uninstall_ja.md)
 
 Uninstall
 ---------

--- a/docs/08-Uninstall_ja.md
+++ b/docs/08-Uninstall_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./08-Uninstall_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./08-Uninstall_en.md) / Japanese
 
 アンインストール
 ----------------

--- a/docs/09-Build_en.md
+++ b/docs/09-Build_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./09-Build_ja.md)
+[top](../README.md) &gt; English / [Japanese](./09-Build_ja.md)
 
 Build
 -----

--- a/docs/09-Build_ja.md
+++ b/docs/09-Build_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./09-Build_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./09-Build_en.md) / Japanese
 
 ビルド方法
 ----------

--- a/docs/10-SetupSKK_en.md
+++ b/docs/10-SetupSKK_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](./10-SetupSKK_ja.md)
+[top](../README.md) &gt; English / [Japanese](./10-SetupSKK_ja.md)
 
 
 How to setup SKK

--- a/docs/10-SetupSKK_ja.md
+++ b/docs/10-SetupSKK_ja.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; [English](./10-SetupSKK_en.md) / Japanese
+[top](../README.md) &gt; [English](./10-SetupSKK_en.md) / Japanese
 
 SKK のセットアップの仕方
 ========================

--- a/docs/history-4.0_en.md
+++ b/docs/history-4.0_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](history-4.0_ja.md)
+[top](../README.md) &gt; English / [Japanese](history-4.0_ja.md)
 
 NYAGOS 4.0.9\_11
 ================

--- a/docs/history-4.0_ja.md
+++ b/docs/history-4.0_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./history-4.0_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./history-4.0_en.md) / Japanese
 
 NYAGOS 4.0.9\_11
 ================

--- a/docs/history-4.1_en.md
+++ b/docs/history-4.1_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](history-4.1_ja.md)
+[top](../README.md) &gt; English / [Japanese](history-4.1_ja.md)
 
 Since 4.1
 =========

--- a/docs/history-4.1_ja.md
+++ b/docs/history-4.1_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./history-4.1_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./history-4.1_en.md) / Japanese
 
 Since 4.1
 =========

--- a/docs/history-4.2_en.md
+++ b/docs/history-4.2_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](history-4.2_ja.md)
+[top](../README.md) &gt; English / [Japanese](history-4.2_ja.md)
 
 NYAGOS 4.2.5\_1
 ===============

--- a/docs/history-4.2_ja.md
+++ b/docs/history-4.2_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./history-4.2_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./history-4.2_en.md) / Japanese
 
 NYAGOS 4.2.5\_1
 ===============

--- a/docs/history-4.3_en.md
+++ b/docs/history-4.3_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](history-4.3_ja.md)
+[top](../README.md) &gt; English / [Japanese](history-4.3_ja.md)
 
 NYAGOS 4.3.3\_5
 ===============

--- a/docs/history-4.3_ja.md
+++ b/docs/history-4.3_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](./history-4.3_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](./history-4.3_en.md) / Japanese
 
 NYAGOS 4.3.3\_5
 ===============

--- a/docs/release_note_en.md
+++ b/docs/release_note_en.md
@@ -1,4 +1,4 @@
-[top](../readme.md) &gt; English / [Japanese](release_note_ja.md)
+[top](../README.md) &gt; English / [Japanese](release_note_ja.md)
 
 ## Deprecations
 

--- a/docs/release_note_ja.md
+++ b/docs/release_note_ja.md
@@ -1,4 +1,4 @@
-[top](../readme_ja.md) &gt; [English](release_note_en.md) / Japanese
+[top](../README_ja.md) &gt; [English](release_note_en.md) / Japanese
 
 ## 廃止・非推奨
 


### PR DESCRIPTION
https://github.com/nyaosorg/nyagos/commit/1e86bcd1c3a8668256ecc08f835ebd5adc3d1553 でREADMEのファイル名がリネームされた際に、READMEへのリンクのパスは修正されなかったため、GitHub上でREADMEに移動しようとすると404になっていました。