### PR TITLE
Add `singleescape` option

### DIFF
--- a/doc/07-LuaFunctions_en.md
+++ b/doc/07-LuaFunctions_en.md
@@ -421,6 +421,17 @@ It customizes the color of input prediction.
 
 e.g., `nyagos.option.predict_color = "\027[0;31;1m"` (red).
 
+### `nyagos.option.singleescape`
+
+When set to true, NYAGOS recognizes a standalone Escape key. As a trade-off, some terminals may split escape sequences depending on input timing, causing them to be interpreted incorrectly (for example, pressing the `↑` key may occasionally insert `[A` instead of moving through the command history).
+
+To restore the CMD.EXE-style behavior where the Escape key clears the current command line, add the following to your .nyagos file:
+
+```lua
+nyagos.option.singleescape = true
+nyagos.key.escape = "KILL_WHOLE_LINE"
+```
+
 ### `nyagos.goversion`
 
 Go-version string to build nyagos.exe

--- a/doc/07-LuaFunctions_ja.md
+++ b/doc/07-LuaFunctions_ja.md
@@ -436,6 +436,17 @@ true の場合、一行入力の前に入力バッファをクリアします。
 
 例: `nyagos.option.predict_color = "\027[0;31;1m"` (赤)
 
+### `nyagos.option.singleescape`
+
+true を設定すると、単独の Escape キーを認識できるようになります。そのかわり、端末によっては制御キーのシーケンスが入力タイミングによって分断され、誤って解釈されることがあります（例: `↑` キーがたまに機能せず、`[A` と入力される）。
+
+CMD.EXE のように Escape キーでコマンドラインをクリアするには、.nyagos に次のように設定します。
+
+```lua
+nyagos.option.singleescape = true
+nyagos.key.escape = "KILL_WHOLE_LINE"
+```
+
 ### `nyagos.goversion`
 
 ビルドに使用した Go のバージョン文字列が格納されます。

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,14 @@ Changelog
 - [v4.2.\*](CHANGELOG-v4.2_en.md)
 - [v4.3.\*](CHANGELOG-v4.3_en.md)
 
+- Make standalone Escape key handling configurable via the `singleescape` option. (#506, #507)  
+  To restore the CMD.EXE-style behavior where the Escape key clears the current command line, add the following to your `.nyagos` file:
+
+  ```lua
+  nyagos.option.singleescape = true
+  nyagos.key.escape = "KILL_WHOLE_LINE"
+  ```
+
 4.4.19\_0
 ---------
 Mar 13, 2026

--- a/doc/CHANGELOG_ja.md
+++ b/doc/CHANGELOG_ja.md
@@ -7,6 +7,14 @@ Changelog
 - [v4.2.\*](CHANGELOG-v4.2_ja.md)
 - [v4.3.\*](CHANGELOG-v4.3_ja.md)
 
+- `singleescape` オプションで、単独の Escape キーを認識できるようにした (#506, #507)  
+  CMD.EXE のように Escape キーでコマンドラインをクリアするには、`.nyagos` に次のように設定します。
+
+  ```lua
+  nyagos.option.singleescape = true
+  nyagos.key.escape = "KILL_WHOLE_LINE"
+  ```
+
 4.4.19\_0
 ---------
 Mar 13, 2026

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nyaosorg/go-inline-animation v0.3.1
 	github.com/nyaosorg/go-readline-ny v1.15.0
 	github.com/nyaosorg/go-readline-skk v0.6.2
-	github.com/nyaosorg/go-ttyadapter v0.6.0
+	github.com/nyaosorg/go-ttyadapter v0.7.0
 	github.com/nyaosorg/go-windows-commandline v0.1.0
 	github.com/nyaosorg/go-windows-consoleicon v0.0.0-20250402034108-1f245d5b597a
 	github.com/nyaosorg/go-windows-findfile v0.0.0-20250402044541-79e3d51e584d
@@ -33,5 +33,6 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
-	github.com/mattn/go-tty/v2 v2.0.0 // indirect
+	github.com/mattn/go-tty v0.0.7 // indirect
+	golang.org/x/term v0.25.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/mattn/go-tty/v2 v2.0.0 h1:AgXDfbKcENaiQbjdQ+o2ZusbtiaOhK1ArFD75d5U6qk=
-github.com/mattn/go-tty/v2 v2.0.0/go.mod h1:azVwsnH46TUJRQPRp/IrUT+8nRkkvjvkESJJxAA4Y48=
+github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
+github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/nyaosorg/glua-ole v0.0.0-20250402051125-b885836720e9 h1:YsqfppqxO/01E6v9/lJfGXgWkpQZDNIGA+BEeorTWdg=
@@ -32,8 +32,8 @@ github.com/nyaosorg/go-readline-ny v1.15.0 h1:zn7DGzmMfLIp6PMhC1s/ux9L2Tujy2jxng
 github.com/nyaosorg/go-readline-ny v1.15.0/go.mod h1:LppK8SXHdjTeNaCxhQlg6uCQAA2lJECohRtRl0hngKM=
 github.com/nyaosorg/go-readline-skk v0.6.2 h1:UUBt4qS0UwEaqKgaju8yQOogSF0Ozs4KXHDEhEsqjDM=
 github.com/nyaosorg/go-readline-skk v0.6.2/go.mod h1:afNC+dqTeuu+5KHNFjbv/up7bfehvHp6HULXljTzvyw=
-github.com/nyaosorg/go-ttyadapter v0.6.0 h1:9/IAk2YKloIyz571pUyW5pzZShWrjxaoZnAKVLqxvdk=
-github.com/nyaosorg/go-ttyadapter v0.6.0/go.mod h1:WxypDPeSfM0+z2yG7q3wVhE/LR4pVXjyGkEk9cA/T7A=
+github.com/nyaosorg/go-ttyadapter v0.7.0 h1:iBOlx7WJ+A0Fn1x28qYJNedjiFt/kWivlrn1+PTSViU=
+github.com/nyaosorg/go-ttyadapter v0.7.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 github.com/nyaosorg/go-windows-commandline v0.1.0 h1:sQP8/iW4r8zdZSWW6lTNajEbxBi7twq47EJ6rjsY4oI=
 github.com/nyaosorg/go-windows-commandline v0.1.0/go.mod h1:u82aK0/yJBpmTGp8QYdNIbq+C8LdLp/tsgR4sOX3ohs=
 github.com/nyaosorg/go-windows-consoleicon v0.0.0-20250402034108-1f245d5b597a h1:71x0OsguXShN1AJCxhvF8mY3GXAY2NiGGOBb9UnuXOo=
@@ -60,5 +60,7 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
+golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=

--- a/internal/commands/more.go
+++ b/internal/commands/more.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 
-	"github.com/nyaosorg/go-ttyadapter/tty8pe"
+	"github.com/nyaosorg/go-ttyadapter/fav"
 	"github.com/nyaosorg/go-windows-mbcs"
 
 	"github.com/nyaosorg/nyagos/internal/nodos"
@@ -32,7 +32,7 @@ func isTerminalIn(in io.Reader) bool {
 }
 
 func getkey() (rune, error) {
-	tty1 := &tty8pe.Tty{}
+	tty1 := new(fav.Tty)
 	if err := tty1.Open(nil); err != nil {
 		return 0, err
 	}
@@ -123,7 +123,7 @@ func more(r io.Reader, cmd Param) error {
 func cmdMore(ctx context.Context, cmd Param) (int, error) {
 	count := 0
 
-	tty1 := &tty8pe.Tty{}
+	tty1 := new(fav.Tty)
 	err := tty1.Open(nil)
 	if err != nil {
 		return 1, err

--- a/internal/config/bool.go
+++ b/internal/config/bool.go
@@ -29,6 +29,8 @@ type BoolFunc = ConfigFunc[bool]
 
 var OptionPredictColor = true
 
+var SingleEscape = false
+
 // Bools are the all global option list.
 var Bools = ignoreCaseSorted.MapToDictionary(map[string]Bool{
 	"completion_hidden": &BoolPtr{
@@ -86,6 +88,11 @@ var Bools = ignoreCaseSorted.MapToDictionary(map[string]Bool{
 		ptr:     &AccessClipboard,
 		usage:   "Use clipboard",
 		noUsage: "Do not use clipboard",
+	},
+	"singleescape": &BoolPtr{
+		ptr:     &SingleEscape,
+		usage:   "Recognize the Escape key by itself",
+		noUsage: "Treat Escape as a prefix key only",
 	},
 })
 

--- a/internal/frame/stream.go
+++ b/internal/frame/stream.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattn/go-colorable"
 
 	"github.com/nyaosorg/go-readline-ny"
+	"github.com/nyaosorg/go-readline-ny/tty8"
 	"github.com/nyaosorg/go-windows-consoleicon"
 
 	"github.com/nyaosorg/nyagos/internal/config"
@@ -63,6 +64,9 @@ func NewCmdStreamConsole(doPrompt func(io.Writer) (int, error)) *CmdStreamConsol
 func (stream *CmdStreamConsole) LazySetup() {
 	if config.AccessClipboard {
 		stream.Editor.Clipboard = OSClipboard{}
+	}
+	if config.SingleEscape {
+		stream.Editor.Tty = new(tty8.Tty)
 	}
 	if _, ok := os.LookupEnv("NO_COLOR"); !ok {
 		stream.Editor.Highlight = []readline.Highlight{

--- a/internal/functions/builtinfunc.go
+++ b/internal/functions/builtinfunc.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mattn/go-isatty"
 
 	"github.com/nyaosorg/go-box/v3"
-	"github.com/nyaosorg/go-ttyadapter/tty8pe"
+	"github.com/nyaosorg/go-ttyadapter/fav"
 	"github.com/nyaosorg/go-windows-findfile"
 
 	"github.com/nyaosorg/nyagos/internal/completion"
@@ -96,7 +96,7 @@ func CmdGetwd(param *Param) []any {
 }
 
 func CmdGetKey(*Param) []any {
-	tty1 := &tty8pe.Tty{}
+	tty1 := new(fav.Tty)
 	if err := tty1.Open(nil); err != nil {
 		return []any{nil, err.Error()}
 	}
@@ -114,7 +114,7 @@ func CmdGetKey(*Param) []any {
 }
 
 func CmdGetKeys(*Param) []any {
-	tty := &tty8pe.Tty{}
+	tty := new(fav.Tty)
 	if err := tty.Open(nil); err != nil {
 		return []any{nil, err.Error()}
 	}
@@ -127,7 +127,7 @@ func CmdGetKeys(*Param) []any {
 }
 
 func CmdGetViewWidth(*Param) []any {
-	tty1 := &tty8pe.Tty{}
+	tty1 := new(fav.Tty)
 	if err := tty1.Open(nil); err != nil {
 		return []any{nil, err.Error()}
 	}


### PR DESCRIPTION
- Make standalone Escape key handling configurable via the `singleescape` option.  
  To restore the CMD.EXE-style behavior where the Escape key clears the current command line, add the following to your `.nyagos` file:
&nbsp;
- `singleescape` オプションで、単独の Escape キーを認識できるようにした。
  CMD.EXE のように Escape キーでコマンドラインをクリアするには、`.nyagos` に次のように設定します。

  ```lua
  nyagos.option.singleescape = true
  nyagos.key.escape = "KILL_WHOLE_LINE"
  ```

- See also: [[FR] Restore Esc key behavior · Issue #506 · nyaosorg/nyagos](https://github.com/nyaosorg/nyagos/issues/506)